### PR TITLE
#3: Format as YYYY-MM-DD to avoid 422 error from API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `GetTimeOffs()` date argument format (YYYY-MM-DD)
+
 ## [0.0.1] - 2022-12-08
 
 - Add `GetEmployees()` and `GetEmployee(id)` to handle `GET /company/employees`

--- a/v1/personio.go
+++ b/v1/personio.go
@@ -17,7 +17,7 @@ const DefaultBaseUrl = "https://api.personio.de/v1"
 
 const timeOffsMaxLimit = 200
 
-const QUERY_DATE_FORMAT = "2006-01-02"
+const queryDateFormat = "2006-01-02"
 
 // Error is an error with an associated status code
 type Error interface {
@@ -466,10 +466,10 @@ func (personio *Client) GetTimeOffs(start *time.Time, end *time.Time, offset int
 
 		query := req.URL.Query()
 		if start != nil {
-			query.Add("start_date", start.Format(QUERY_DATE_FORMAT))
+			query.Add("start_date", start.Format(queryDateFormat))
 		}
 		if end != nil {
-			query.Add("end_date", end.Format(QUERY_DATE_FORMAT))
+			query.Add("end_date", end.Format(queryDateFormat))
 		}
 
 		var stepLimit = limit - count

--- a/v1/personio.go
+++ b/v1/personio.go
@@ -443,10 +443,10 @@ func (personio *Client) GetTimeOffs(start *time.Time, end *time.Time, offset int
 
 		query := req.URL.Query()
 		if start != nil {
-			query.Add("start_date", start.Format(time.RFC3339))
+			query.Add("start_date", start.Format("2006-01-02"))
 		}
 		if end != nil {
-			query.Add("end_date", end.Format(time.RFC3339))
+			query.Add("end_date", end.Format("2006-01-02"))
 		}
 
 		var stepLimit = limit - count

--- a/v1/personio.go
+++ b/v1/personio.go
@@ -17,6 +17,8 @@ const DefaultBaseUrl = "https://api.personio.de/v1"
 
 const timeOffsMaxLimit = 200
 
+const QUERY_DATE_FORMAT = "2006-01-02"
+
 // Error is an error with an associated status code
 type Error interface {
 	error
@@ -443,10 +445,10 @@ func (personio *Client) GetTimeOffs(start *time.Time, end *time.Time, offset int
 
 		query := req.URL.Query()
 		if start != nil {
-			query.Add("start_date", start.Format("2006-01-02"))
+			query.Add("start_date", start.Format(QUERY_DATE_FORMAT))
 		}
 		if end != nil {
-			query.Add("end_date", end.Format("2006-01-02"))
+			query.Add("end_date", end.Format(QUERY_DATE_FORMAT))
 		}
 
 		var stepLimit = limit - count

--- a/v1/personio_test.go
+++ b/v1/personio_test.go
@@ -100,13 +100,13 @@ func (p *PersonioMock) PersonioMockHandler(w http.ResponseWriter, req *http.Requ
 		var errStart error
 		var errEnd error
 		if startArg != "" {
-			start, errStart = time.Parse(time.RFC3339, startArg)
+			start, errStart = time.Parse(QUERY_DATE_FORMAT, startArg)
 		} else {
 			start = time.Time{}
 		}
 
 		if endArg != "" {
-			end, errEnd = time.Parse(time.RFC3339, endArg)
+			end, errEnd = time.Parse(QUERY_DATE_FORMAT, endArg)
 		} else {
 			end = util.PersonioDateMax
 		}

--- a/v1/personio_test.go
+++ b/v1/personio_test.go
@@ -100,13 +100,13 @@ func (p *PersonioMock) PersonioMockHandler(w http.ResponseWriter, req *http.Requ
 		var errStart error
 		var errEnd error
 		if startArg != "" {
-			start, errStart = time.Parse(QUERY_DATE_FORMAT, startArg)
+			start, errStart = time.Parse(queryDateFormat, startArg)
 		} else {
 			start = time.Time{}
 		}
 
 		if endArg != "" {
-			end, errEnd = time.Parse(QUERY_DATE_FORMAT, endArg)
+			end, errEnd = time.Parse(queryDateFormat, endArg)
 		} else {
 			end = util.PersonioDateMax
 		}


### PR DESCRIPTION
### What does this PR do?

- Experience using this project has shown that a 422 error is returned when the full RFC3339 date is provided to the time-offs endpoint.

### What is the effect of this change to users?

None

### How does it look like?

N/A

### Any background context you can provide?

I raised issue #3 regarding this

### What is needed from the reviewers?

Just a glance and tick. :) 

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

Unlikely, up to you guys

- [ ] CHANGELOG.md has been updated (if it exists)
