### PR TITLE
GetEmployees(): return more than 200 employees, re-factor

### DIFF
--- a/v1/personio_test.go
+++ b/v1/personio_test.go
@@ -112,11 +112,11 @@ func (p *PersonioMock) PersonioMockHandler(w http.ResponseWriter, req *http.Requ
 		}
 
 		if limitArg == "" {
-			limit = timeOffsMaxLimit
+			limit = pagingMaxLimit
 		}
 
 		if errStart != nil || errEnd != nil || end.Before(start) ||
-			(limitArg != "" && (limitErr != nil || limit > timeOffsMaxLimit || limit < 1)) ||
+			(limitArg != "" && (limitErr != nil || limit > pagingMaxLimit || limit < 1)) ||
 			(offsetArg != "" && (offsetErr != nil || offset < 0)) {
 			w.WriteHeader(http.StatusBadRequest)
 			return


### PR DESCRIPTION
## Reasoning

The `/company/employees` endpoint also supports paging.

Thus `GetEmployees()` will only return the first page of employees (limited to 200 objects by default).

## Fix

- `GetEmployees()` shall return all employees
- All paging functions shall share common page handling code (ie. `GetTimeOffs()`)
- Our interface shall not change (no breaking change)