### PR TITLE
fix: add TimeOff.Comment field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `TimeOff.Comment` field
+
 ## [0.2.0] - 2023-06-04
 
 - Renamed `GetListValue()` to `GetTagValues()`

--- a/v1/personio.go
+++ b/v1/personio.go
@@ -209,6 +209,7 @@ type Employee struct {
 type TimeOff struct {
 	Id           int64        `json:"id"`
 	Status       string       `json:"status"`
+	Comment      string       `json:"comment"`
 	StartDate    time.Time    `json:"start_date"`
 	EndDate      time.Time    `json:"end_date"`
 	DaysCount    float64      `json:"days_count"`

--- a/v1/personio_test.go
+++ b/v1/personio_test.go
@@ -515,6 +515,17 @@ func TestClient_GetTimeOffs(t *testing.T) {
 			continue
 		}
 
+		for _, timeOff := range timeOffs {
+			if len(timeOff.Comment) <= 0 {
+				t.Errorf("[%d] Time-off with ID %d has empty comment", testNumber, timeOff.Id)
+			}
+		}
+		for _, timeOff := range timeOffs2 {
+			if len(timeOff.Comment) <= 0 {
+				t.Errorf("[%d] Time-off with ID %d has empty comment", testNumber, timeOff.Id)
+			}
+		}
+
 		for _, id := range testCase.wantIds {
 			found := false
 			for i := range timeOffs {

--- a/v1/testdata/time-offs-body.json
+++ b/v1/testdata/time-offs-body.json
@@ -6,7 +6,7 @@
       "attributes": {
         "id": 125814620,
         "status": "approved",
-        "comment": "",
+        "comment": "bye",
         "start_date": "2022-09-05T00:00:00+02:00",
         "end_date": "2022-09-09T00:00:00+02:00",
         "days_count": 5,
@@ -62,7 +62,7 @@
       "attributes": {
         "id": 125682392,
         "status": "approved",
-        "comment": "",
+        "comment": "hello",
         "start_date": "2022-09-07T00:00:00+02:00",
         "end_date": "2022-09-14T00:00:00+02:00",
         "days_count": 6,


### PR DESCRIPTION
## Summary

Adds the missing field `Comment` to the `TimeOff` structure.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
