### PR TITLE
Remove duplicate pull request template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,3 +1,0 @@
-## Checklist
-
-- [ ] Update changelog in CHANGELOG.md.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27797 - This PR removes a duplicate PR template file. There is one already in .github/pull_request_template.md which will be kept.