### PR TITLE
v1.GetTimeOffsMapped(): function to get time-offs with accurate times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `v1.GetTimeOffsMapped()` function
+
 ## [0.3.0] - 2023-07-05
 
 ### Added

--- a/v1/testdata/time-offs-body.json
+++ b/v1/testdata/time-offs-body.json
@@ -112,6 +112,62 @@
         "created_at": "2022-07-26T11:52:55+02:00",
         "updated_at": "2022-10-02T19:13:09+02:00"
       }
+    },
+    {
+      "type": "TimeOffPeriod",
+      "attributes": {
+        "id": 125682393,
+        "status": "approved",
+        "comment": "later-this-year",
+        "start_date": "2022-12-01T00:00:00+02:00",
+        "end_date": "2022-12-01T00:00:00+02:00",
+        "days_count": 0.5,
+        "half_day_start": 0,
+        "half_day_end": 1,
+        "time_off_type": {
+          "type": "TimeOffType",
+          "attributes": {
+            "id": 155627,
+            "name": "Vacation",
+            "category": "paid_vacation"
+          }
+        },
+        "employee": {
+          "type": "Employee",
+          "attributes": {
+            "id": {
+              "label": "ID",
+              "value": 6205887,
+              "type": "integer",
+              "universal_id": "id"
+            },
+            "first_name": {
+              "label": "First name",
+              "value": "El",
+              "type": "standard",
+              "universal_id": "first_name"
+            },
+            "last_name": {
+              "label": "Last name",
+              "value": "Gonzo",
+              "type": "standard",
+              "universal_id": "last_name"
+            },
+            "email": {
+              "label": "Email",
+              "value": "gonzo@giantswarm.io",
+              "type": "standard",
+              "universal_id": "email"
+            }
+          }
+        },
+        "created_by": "El Gonzo",
+        "certificate": {
+          "status": "not-required"
+        },
+        "created_at": "2022-07-26T11:52:55+02:00",
+        "updated_at": "2022-10-02T19:13:09+02:00"
+      }
     }
   ]
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30269

### Summary

This PR adds a function `v1.GetTimeOffsMapped()` which adds a level on top of the `v1.GetTimeOffs()` API, maps the embedded half-day/daycount fields to times and filters the TimeOff objects by the given certain time range.

This is added as a utility function, because the logic to parse `v1.TimeOff` objects "half-day" related fields isn't straight-forward.