### PR TITLE
Reduced pagingMaxLimit to 100 in order to comply with upcoming Personio API changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `Authenticate()` to handle `POST /auth`
 - Add Personio API v1 client
 
-[Unreleased]: https://github.com/giantswarm/personio-go/compare/v0.5.0...HEAD
-[0.5.0]: https://github.com/giantswarm/personio-go/compare/v0.4.0...v0.5.0
+[Unreleased]: https://github.com/giantswarm/personio-go/compare/v0.4.0...HEAD
 [0.4.0]: https://github.com/giantswarm/personio-go/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/giantswarm/personio-go/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/giantswarm/personio-go/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.0] - 2024-10-16
-
-- Reduced pagingMaxLimit to 100 in order to comply with upcoming Personio API changes
-
 ## [0.4.0] - 2024-03-26
 
 ### Added

--- a/v1/personio.go
+++ b/v1/personio.go
@@ -17,7 +17,7 @@ import (
 
 const DefaultBaseUrl = "https://api.personio.de/v1"
 
-const pagingMaxLimit = 200
+const pagingMaxLimit = 100
 
 const intMax = 2147483647
 


### PR DESCRIPTION

Personio will reduce the limit parameter to 100 on December 7th 2024.

### What does this PR do?

Reduces the const `pagingMaxLimit` from 200 to 100.

### What is the effect of this change to users?

Users will be able to continue using the Personio API without any issues.

### How does it look like?

![image](https://github.com/user-attachments/assets/300f2e66-880b-4ee7-a5c7-3822d706c4dc)

### Any background context you can provide?

[Pagination enforcement - V1 Employees API](https://developer.personio.de/changelog/pagination-enforcement-v1-employees-api)

### What is needed from the reviewers?

Review, test and merge

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated